### PR TITLE
Remove null-initialization of object field

### DIFF
--- a/HiPic/MainWindow.xaml.cs
+++ b/HiPic/MainWindow.xaml.cs
@@ -12,7 +12,7 @@ namespace HiPic
     /// </summary>
     public partial class MainWindow : Window
     {
-        WindowViewModel vm = null;
+        WindowViewModel vm;
         IntPtr foreWindow;
         BitmapImage bmp;
 


### PR DESCRIPTION
When creating an object on the managed heap, The .NET runtime ensures
that all of its fields are initialized to zero before calling its
constructor.  It is therefore redundant to initialize a field manually
to null in the field declaration.

Nonetheless, such initialization is redundant anyway if the field is to
be re-assigned in the constructor.